### PR TITLE
Check if database table "users" exists.

### DIFF
--- a/bin/gpx2spatialite
+++ b/bin/gpx2spatialite
@@ -143,6 +143,14 @@ def main():
 
     # -------------------------------------------------------------------------
 
+    if not g2s.check_if_table_exists(conn, "users"):
+        print("Unable to find database table \"users\".")
+        print("Use `gpx2spatialite_create_db` to create \
+the database beforehand.")
+        cursor.close()
+        conn.close()
+        sys.exit(1)
+
     userid = g2s.get_user_id(cursor, username)
     if userid == -1:
         # user name is not in database - ask to add

--- a/gpx2spatialite/db_helper.py
+++ b/gpx2spatialite/db_helper.py
@@ -53,3 +53,19 @@ def init_spatial_metadata(connection):
             connection.execute(query)
     except spatialite.Error as err:
         print('SQL Error: ' + str(err))
+
+
+def check_if_table_exists(connection, table_name):
+    """
+    Returns True if table exists otherwise False
+    """
+    if connection is None:
+        raise "Invalid connection"
+
+    if table_name is None or len(table_name) < 1:
+        raise "Invalid table name"
+
+    sql = "SELECT count(*) FROM sqlite_master "
+    sql += "WHERE name='{0}' and type='table'"
+    cursor = connection.execute(sql.format(table_name))
+    return True if int(cursor.fetchone()[0]) > 0 else False

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -115,3 +115,12 @@ class TestDb:
         assert wpt_row[6] == 1
         assert wpt_row[7] is None
         assert wpt_row[9] == "POINT(-121.17042 37.085751)"
+
+    def test_check_if_table_exists(self, db):
+        table_exists = gpx2spatialite \
+            .check_if_table_exists(db.conn, "users")
+        assert table_exists is True
+
+        table_exists = gpx2spatialite \
+            .check_if_table_exists(db.conn, "users-not-existing")
+        assert table_exists is False


### PR DESCRIPTION
If you run `gpx2spatialite -d <path/to/database> -u <user_id> <path/to/gpx>` without knowledge of `gpx2spatialite_create_db` `gpx2spatialite` fails with an error.
With this commit the user is told what to do.
